### PR TITLE
Display section sort order

### DIFF
--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
 import type { FieldAppSDK } from '@contentful/app-sdk';
+import '../styles/preview.css';
 
 type PreviewProps = { sdk: FieldAppSDK };
 
@@ -17,6 +18,9 @@ export default function Preview({ sdk }: PreviewProps) {
   useEffect(() => {
     (async () => {
       try {
+        if (!sdk.entry || !sdk.space) {
+          return;
+        }
         const entrySys       = sdk.entry.getSys();
         const entryId        = entrySys.id;
         const contentTypeId  = entrySys.contentType.sys.id;
@@ -41,10 +45,12 @@ export default function Preview({ sdk }: PreviewProps) {
         const markup = items
           .map(item => {
             const fields = item.fields as any;
-            const title  = fields?.[sectionTitleField]?.[locale] ?? '(Untitled)';
-            const body   = fields?.body?.[locale];
+            const title      = fields?.[sectionTitleField]?.[locale] ?? '(Untitled)';
+            const body       = fields?.body?.[locale];
+            const sortOrder  = fields?.sortOrder?.[locale] ?? fields?.sortOrder ?? '';
             return `
               <div class="section-card">
+                <div class="section-sort">${sortOrder}</div>
                 <h3>${title}</h3>
                 ${body ? documentToHtmlString(body) : '<em>No content</em>'}
               </div>`;

--- a/src/locations/Field.spec.tsx
+++ b/src/locations/Field.spec.tsx
@@ -9,9 +9,9 @@ vi.mock('@contentful/react-apps-toolkit', () => ({
 }));
 
 describe('Field component', () => {
-  it('Component text exists', () => {
+  it('Renders preview placeholder', () => {
     const { getByText } = render(<Field />);
 
-    expect(getByText('Hello Entry Field Component (AppId: test-app)')).toBeTruthy();
+    expect(getByText('Loading preview …')).toBeTruthy();
   });
 });

--- a/src/styles/preview.css
+++ b/src/styles/preview.css
@@ -29,6 +29,12 @@ body, .preview-root {
     font-weight: 600;
     margin: 0 0 .75rem;
   }
+
+  /* sort order label */
+  .section-sort {
+    font-weight: 700;
+    margin-bottom: 0.25rem;
+  }
   
   /* rich-text body */
   .section-card p { margin: 0 0 .6rem; }

--- a/test/mocks/mockSdk.ts
+++ b/test/mocks/mockSdk.ts
@@ -7,6 +7,10 @@ const mockSdk: any = {
     setReady: vi.fn(),
     getCurrentState: vi.fn(),
   },
+  window: {
+    startAutoResizer: vi.fn(),
+    updateHeight: vi.fn(),
+  },
   ids: {
     app: 'test-app',
   },


### PR DESCRIPTION
## Summary
- show sorting order number in library section cards
- style the sort order label above the section title
- load preview styles
- mock window methods for tests
- update field test for new preview component

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_684207e2adb08327848c6e6a79a6fc62